### PR TITLE
Use cast sequence if possible.

### DIFF
--- a/HealthstoneAutoMacro.toc
+++ b/HealthstoneAutoMacro.toc
@@ -1,5 +1,5 @@
 ## Interface: 80100
-## Version: 0.1.0-alpha
+## Version: 0.3.0-alpha
 ## Title: Healthstone Auto Macro
 ## Author: ollidiemaus
 ## Notes: Updates the Macro HAMHealthPot to use either Healthstone or Coastal Healing Potion

--- a/code.lua
+++ b/code.lua
@@ -1,4 +1,6 @@
 -- This file is loaded from "HealthstoneAutoMacro.toc"
+-- #showtooltip
+-- /castsequence reset=combat Healthstone, Coastal Healing Potion
 do
 
 local HSId = 5512;
@@ -56,16 +58,19 @@ HealPotMacroIcon:SetScript("OnEvent",function(self,event,...)
   if onCombat==false then
     local HSName, SilasPotName, NormalPotName, EmeraldName = getPotNames(); 
     local HealthstoneNbr, SilasNbr, NormalPotNbr, EmeraldPotNbr = getPotCount()
-    local macroStr = "#showtooltip \n/castsequence reset=combat ";
+    local macroStr = ""
 
-    if HealthstoneNbr > 0 and SilasNbr > 0 then 
-      macroStr = macroStr .. HSName .. ", " .. SilasPotName;
-    elseif HealthstoneNbr > 0 and EmeraldPotNbr > 0 then
-      macroStr = macroStr .. HSName .. ", " .. EmeraldName;
-    elseif HealthstoneNbr > 0 and NormalPotNbr > 0 then
-      macroStr = macroStr .. HSName .. ", " .. NormalPotName;
-    elseif HealthstoneNbr > 0 then
-      macroStr = "#showtooltip \n/use " .. HSName;
+    if HealthstoneNbr > 0 then
+      macroStr = "#showtooltip \n/castsequence reset=combat " .. HSName .. ", ";
+      if SilasNbr > 0 then
+        macroStr = macroStr .. SilasPotName;
+      elseif EmeraldPotNbr > 0 then
+        macroStr = macroStr .. EmeraldName;
+      elseif NormalPotNbr > 0 then
+        macroStr = macroStr .. NormalPotName;
+      else
+        macroStr = "#showtooltip \n/use " .. HSName;
+      end
     elseif SilasNbr > 0 then
       macroStr = "#showtooltip \n/use " .. SilasPotName;
     elseif EmeraldPotNbr > 0 then

--- a/code.lua
+++ b/code.lua
@@ -36,6 +36,7 @@ function getPots()
   }
 end
 function getHs()
+  HSName = GetItemInfo(HSId);
   if HSName==nil then
     HSName = "Healthstone"
   end

--- a/code.lua
+++ b/code.lua
@@ -1,14 +1,83 @@
 -- This file is loaded from "HealthstoneAutoMacro.toc"
-
 do
 
-local HealPotMacroIcon = CreateFrame("Frame")
-HealPotMacroIcon:RegisterEvent("BAG_UPDATE")
-HealPotMacroIcon:RegisterEvent("PLAYER_LOGIN")
+local HSId = 5512;
+local SilasPotId = 156634;
+local NormalPotId = 152494;
+local EmeraldId = 166799; -- Emerald of Vigor
+
+function getPotNames()
+  HSName = GetItemInfo(HSId);
+  SilasPotName = GetItemInfo(SilasPotId);
+  NormalPotName = GetItemInfo(NormalPotId);
+  EmeraldName = GetItemInfo(EmeraldId);
+
+  -- fall back on connect sometimes GetItem fail
+  if HSName==nil then
+    HSName = "Healthstone"
+  end
+  if SilasPotName==nil then
+    SilasPotName = "Silas' Vial of Continuous Curing"
+  end
+  if NormalPotName==nil then
+    NormalPotName = "Coastal Healing Potion"
+  end
+  if EmeraldName==nil then
+    EmeraldName = "Emerald of Vigor"
+  end
+  return HSName, SilasPotName, NormalPotName, EmeraldName
+end
+function getPotCount()
+  HealthstoneNbr = GetItemCount(HSId);
+  SilasNbr = GetItemCount(SilasPotId);
+  NormalPotNbr = GetItemCount(NormalPotId);
+  EmeraldPotNbr = GetItemCount(EmeraldId);
+  return HealthstoneNbr, SilasNbr, NormalPotNbr, EmeraldPotNbr
+end
+
+local onCombat = true;
+local HealPotMacroIcon = CreateFrame("Frame");
+HealPotMacroIcon:RegisterEvent("BAG_UPDATE");
+HealPotMacroIcon:RegisterEvent("PLAYER_LOGIN");
+HealPotMacroIcon:RegisterEvent("PLAYER_REGEN_ENABLED");
+HealPotMacroIcon:RegisterEvent("PLAYER_REGEN_DISABLED");
 HealPotMacroIcon:SetScript("OnEvent",function(self,event,...)
- pot = GetItemCount("Healthstone")==0 and "Coastal Healing Potion" or "Healthstone"
- item = GetItemCount("Silas' Vial of Continuous Curing")==0 and pot or "Silas' Vial of Continuous Curing"
- EditMacro("HAMHealthPot", "HAMHealthPot", nil, "#showtooltip \n/use " .. item, 1, nil)
+  if event=="PLAYER_LOGIN" then
+    onCombat = false;
+  end
+  if event=="PLAYER_REGEN_DISABLED" then
+    onCombat = true;
+    return ;
+  end
+  if event=="PLAYER_REGEN_ENABLED" then
+    onCombat = false;
+  end
+
+  if onCombat==false then
+    local HSName, SilasPotName, NormalPotName, EmeraldName = getPotNames(); 
+    local HealthstoneNbr, SilasNbr, NormalPotNbr, EmeraldPotNbr = getPotCount()
+    local macroStr = "#showtooltip \n/castsequence reset=combat ";
+
+    if HealthstoneNbr > 0 and SilasNbr > 0 then 
+      macroStr = macroStr .. HSName .. ", " .. SilasPotName;
+    elseif HealthstoneNbr > 0 and EmeraldPotNbr > 0 then
+      macroStr = macroStr .. HSName .. ", " .. EmeraldName;
+    elseif HealthstoneNbr > 0 and NormalPotNbr > 0 then
+      macroStr = macroStr .. HSName .. ", " .. NormalPotName;
+    elseif HealthstoneNbr > 0 then
+      macroStr = "#showtooltip \n/use " .. HSName;
+    elseif SilasNbr > 0 then
+      macroStr = "#showtooltip \n/use " .. SilasPotName;
+    elseif EmeraldPotNbr > 0 then
+      macroStr = "#showtooltip \n/use " .. EmeraldName;
+    elseif NormalPotNbr > 0 then
+      macroStr = "#showtooltip \n/use " .. NormalPotName;
+    else
+      macroStr = "#showtooltip"
+    end
+
+    EditMacro("HAMHealthPot", "HAMHealthPot", nil, macroStr, 1, nil)
+  end
 end)
 
 end


### PR DESCRIPTION
added feature :
 - Try to castsequence Healstone -> Silas' pot /  Emerald of Vigor then Healing Potion.
if not use possible simple /use
 - use item ID for multi language
 - changed event register to modify the macro only off combat